### PR TITLE
feat: add mysql healthcheck in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3.9'
 
 services:
     app:
@@ -7,7 +7,8 @@ services:
         ports:
             - 3000:3000
         depends_on:
-            - mysql_self
+            mysql_self:
+                condition: service_healthy
         networks:
             - backend
         environment:
@@ -38,6 +39,11 @@ services:
             - backend
         volumes:
             - /var/lib/mysql-self
+        healthcheck:
+            test: mysqladmin ping -h localhost -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
+            interval: 10s
+            timeout: 5s
+            retries: 5
 
 networks:
     backend:


### PR DESCRIPTION
Add mysql health check in docker-compose

Fix connect error before mysql container is ready

app-1         | node:internal/process/promises:289
app-1         |             triggerUncaughtException(err, true /* fromPromise */);
app-1         |             ^
app-1         |
app-1         | Error: connect ECONNREFUSED 172.26.0.2:3306
app-1         |     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1606:16)
app-1         |     --------------------
app-1         |     at Protocol._enqueue (/app/node_modules/mysql/lib/protocol/Protocol.js:144:48)
app-1         |     at Protocol.handshake (/app/node_modules/mysql/lib/protocol/Protocol.js:51:23)
app-1         |     at PoolConnection.connect (/app/node_modules/mysql/lib/Connection.js:116:18)
app-1         |     at Pool.getConnection (/app/node_modules/mysql/lib/Pool.js:48:16)
app-1         |     at /app/node_modules/typeorm/driver/mysql/MysqlDriver.js:1012:18
app-1         |     at new Promise (<anonymous>)
app-1         |     at MysqlDriver.createPool (/app/node_modules/typeorm/driver/mysql/MysqlDriver.js:1009:16)
app-1         |     at MysqlDriver.connect (/app/node_modules/typeorm/driver/mysql/MysqlDriver.js:305:36)
app-1         |     at DataSource.initialize (/app/node_modules/typeorm/data-source/DataSource.js:136:27)
app-1         |     at Object.<anonymous> (/app/dist/src/Adapters/Secondary/MySqlAdapter/index.js:23:23) {
app-1         |   errno: -111,
app-1         |   code: 'ECONNREFUSED',
app-1         |   syscall: 'connect',
app-1         |   address: '172.26.0.2',
app-1         |   port: 3306,
app-1         |   fatal: true
app-1         | }

to repeat this error delete app image and volume, run docker compose up again and follow the app log