### PR TITLE
Improving manifestos

### DIFF
--- a/k8s/api/configmap.yaml
+++ b/k8s/api/configmap.yaml
@@ -5,9 +5,10 @@ metadata:
   namespace: fiap-soat
 data:
   DB_TYPE: 'mysql'
-  DB_HOST: 'mysql_self'
+  DB_HOST: 'sst-db-svc'
   DB_PORT: '3306'
   DB_USERNAME: 'mcdonalds'
   DB_PASSWORD: 'mcdonalds#1234'
   DB_DATABASE: 'self-service'
   PORT: '3000'
+  SWAGGER_URL: 'localhost'

--- a/k8s/api/configmap.yaml
+++ b/k8s/api/configmap.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: self-service-totem-env
+  name: sst-env
+  namespace: fiap-soat
 data:
   DB_TYPE: 'mysql'
   DB_HOST: 'mysql_self'

--- a/k8s/api/deployment.yaml
+++ b/k8s/api/deployment.yaml
@@ -1,23 +1,24 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: self-service-totem-api
+  name: sst-api
+  namespace: fiap-soat
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: self-service-totem-api
+      app: sst-api
   template:
     metadata:
       labels:
-        app: self-service-totem-api
+        app: sst-api
     spec:
       containers:
-      - name: self-service-totem-api
+      - name: sst-api
         image: marcelors/self-service-totem-api:v1.0.3
         envFrom:
         - configMapRef:
-            name: self-service-totem-env
+            name: sst-env
 
         startupProbe:
           httpGet:

--- a/k8s/api/deployment.yaml
+++ b/k8s/api/deployment.yaml
@@ -13,17 +13,30 @@ spec:
       labels:
         app: sst-api
     spec:
-      containers:
-      - name: sst-api
-        image: marcelors/self-service-totem-api:v1.0.3
+      initContainers:
+      - name: migrate
+        image: evilfeeh/self-service-totem:1.0.4-rc2
+        command: ["npm", "run", "migration:up"]
         envFrom:
+        - secretRef:
+            name: sst-api-secrets
         - configMapRef:
             name: sst-env
-
+      containers:
+      - name: sst-api
+        image: evilfeeh/self-service-totem:1.0.4-rc2
+        ports:
+        - containerPort: 3000
+        envFrom:
+        - secretRef:
+            name: sst-api-secrets
+        - configMapRef:
+            name: sst-env
         startupProbe:
           httpGet:
             path: /api/health
             port: 3000
+          initialDelaySeconds: 30
           periodSeconds: 3
           failureThreshold: 30
 

--- a/k8s/api/hpa.yaml
+++ b/k8s/api/hpa.yaml
@@ -1,12 +1,13 @@
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: self-service-totem-api-hpa
+  name: sst-api-hpa
+  namespace: fiap-soat
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: self-service-totem-api
+    name: sst-api
   minReplicas: 1
   maxReplicas: 5
   targetCPUUtilizationPercentage: 75

--- a/k8s/api/secrets.yaml
+++ b/k8s/api/secrets.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sst-api-secrets
+  namespace: fiap-soat
+data:
+  DB_TYPE: bXlzcWw=
+  DB_HOST: c3N0LWRiLXN2Yw==
+  DB_PORT: '3306'
+  DB_USERNAME: bWNkb25hbGRz
+  DB_PASSWORD: bWNkb25hbGRzIzEyMzQ=
+  DB_DATABASE: c2VsZi1zZXJ2aWNl
+  PORT: '3000'

--- a/k8s/api/service.yaml
+++ b/k8s/api/service.yaml
@@ -1,15 +1,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: self-service-totem-api
+  name: sst-api
+  namespace: fiap-soat
   labels:
-    app: self-service-totem-api
+    app: sst-api
 spec:
   selector:
-    app: self-service-totem-api
+    app: sst-api
   type: LoadBalancer
   ports:
-  - name: self-service-totem-api
+  - name: sst-api
     protocol: TCP
     port: 80
     targetPort: 3000

--- a/k8s/mysql/pv.yaml
+++ b/k8s/mysql/pv.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: sst-pv
+  namespace: fiap-soat
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Recycle
+  claimRef:
+    namespace: fiap-soat
+    name: sst-database-pvc
+  hostPath:
+    path: "/mnt/data"

--- a/k8s/mysql/pvc.yaml
+++ b/k8s/mysql/pvc.yaml
@@ -1,11 +1,12 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: database-pvc
+  name: sst-database-pvc
+  namespace: fiap-soat
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: self-service-totem-database-sc
+  storageClassName: sst-database-sc
   resources:
     requests:
       storage: 256Mi

--- a/k8s/mysql/pvc.yaml
+++ b/k8s/mysql/pvc.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: sst-database-sc
   resources:
     requests:
       storage: 256Mi

--- a/k8s/mysql/secrets.yaml
+++ b/k8s/mysql/secrets.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: self-service-totem-database-secrets
+  name: sst-database-secrets
+  namespace: fiap-soat
 data:
   MYSQL_ROOT_PASSWORD: cm9vdFVzZXIjMTIzNA==
   MYSQL_DATABASE: c2VsZi1zZXJ2aWNl

--- a/k8s/mysql/service.yaml
+++ b/k8s/mysql/service.yaml
@@ -1,13 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: self-service-totem-database
+  name: sst-database
+  namespace: fiap-soat
   labels:
-    app: self-service-totem-database
+    app: sst-database
 spec:
   selector:
-    app: self-service-totem-database
+    app: sst-database
   clusterIP: None
   ports:
-  - name: self-service-totem-database-port
+  - name: sst-database-port
     port: 80

--- a/k8s/mysql/service.yaml
+++ b/k8s/mysql/service.yaml
@@ -1,14 +1,17 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: sst-database
+  name: sst-db-svc
   namespace: fiap-soat
   labels:
-    app: sst-database
+    app: sst-db-svc
+    app.kubernetes.io/name: sst-db-svc
 spec:
   selector:
     app: sst-database
   clusterIP: None
   ports:
-  - name: sst-database-port
-    port: 80
+  - name: sst-db-port
+    protocol: TCP
+    port: 3306
+    targetPort: 3306

--- a/k8s/mysql/statefulSet.yaml
+++ b/k8s/mysql/statefulSet.yaml
@@ -18,7 +18,7 @@ spec:
         image: mysql:5.7
         ports:
         - containerPort: 80
-          name: sst-database-port
+          name: sst-db-port
         readinessProbe:
           exec:
             command:
@@ -54,5 +54,4 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 256Mi
-      storageClassName: sst-database-sc
+          storage: 512Mi

--- a/k8s/mysql/statefulSet.yaml
+++ b/k8s/mysql/statefulSet.yaml
@@ -1,23 +1,24 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: sef-service-totem-database
+  name: sst-database
+  namespace: fiap-soat
 spec:
   selector:
     matchLabels:
-      app: self-service-totem-database
+      app: sst-database
   serviceName: database
   template:
     metadata:
       labels:
-        app: self-service-totem-database
+        app: sst-database
     spec:
       containers:
       - name: mysql
         image: mysql:5.7
         ports:
         - containerPort: 80
-          name: self-service-totem-database-port
+          name: sst-database-port
         readinessProbe:
           exec:
             command:
@@ -40,18 +41,18 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
-        - mountPath: /var/lib/self-service-totem-database-volume
-          name: self-service-totem-database-volume
+        - mountPath: /var/lib/sst-database-volume
+          name: sst-database-volume
         envFrom:
         - secretRef:
-            name: self-service-totem-database-secrets
+            name: sst-database-secrets
   volumeClaimTemplates:
   - metadata:
-      name: self-service-totem-database-volume
+      name: sst-database-volume
     spec:
       accessModes:
       - ReadWriteOnce
       resources:
         requests:
           storage: 256Mi
-      storageClassName: self-service-totem-database-sc
+      storageClassName: sst-database-sc

--- a/k8s/mysql/statefulSet.yaml
+++ b/k8s/mysql/statefulSet.yaml
@@ -22,13 +22,17 @@ spec:
         readinessProbe:
           exec:
             command:
+            - bin/sh
+            - -c
+            - > 
             - mysqladmin
             - ping
             - -h
             - localhost
             - -u
-            - $$MYSQL_USER
-            - --password=$$MYSQL_PASSWORD
+            - MYSQL_USER=$(printenv MYSQL_USER)
+            - MYSQL_PASSWORD=$(printenv MYSQL_PASSWORD)
+            - mysqladmin ping -h localhost -u MYSQL_USER -p MYSQL_PASSWORD
           failureThreshold: 5
           periodSeconds: 5
           successThreshold: 1

--- a/k8s/mysql/statefulSet.yaml
+++ b/k8s/mysql/statefulSet.yaml
@@ -17,7 +17,7 @@ spec:
       - name: mysql
         image: mysql:5.7
         ports:
-        - containerPort: 80
+        - containerPort: 3306
           name: sst-db-port
         readinessProbe:
           exec:
@@ -45,17 +45,17 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
-        - mountPath: /var/lib/sst-database-volume
-          name: sst-database-volume
+        - mountPath: /var/lib/sst-database-pvc
+          name: sst-database-pvc
         envFrom:
         - secretRef:
             name: sst-database-secrets
   volumeClaimTemplates:
   - metadata:
-      name: sst-database-volume
+      name: sst-database-pvc
     spec:
       accessModes:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 512Mi
+          storage: 2Gi

--- a/k8s/mysql/storageClass.yaml
+++ b/k8s/mysql/storageClass.yaml
@@ -1,7 +1,8 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: self-service-totem-database-sc
+  name: sst-database-sc
+  namespace: fiap-soat
   annotations:
     storageClass.kubernetes.io/is-default-class: "true"
 provisioner: kubernetes.io/pce-pd

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fiap-soat


### PR DESCRIPTION
- For the limits of characters, I needed to change the length of those texts to a shorter version:
they are using the prefix: sst
- I also added a namespace to facilitate the management of pods, services, pvc, etc.
- Corrected the readiness probe command into statefulset, fixing the database pod issue
